### PR TITLE
Add Device Roles

### DIFF
--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -194,7 +194,9 @@ Site objects include a site diagram from IPFabric, which is using the new custom
 | vendor             | Device.vendor        | Device.manufacturer    |
 | model              | Device.model         | Device.device_type     |
 | sn                 | Device.serial_number | Device.serial          |
+| devType            | Device.role          | Device.device_role     |
 
+> Note: The corresponding DeviceRole.name can be overwritten for customization. Mapping is done via the CustomField `IPFabric_Type` on the DeviceRole object.
 
 ### IPFabric Interface
 
@@ -219,7 +221,3 @@ Site objects include a site diagram from IPFabric, which is using the new custom
 | vlanId             | Vlan.vid       | VLAN.vid               |
 | status             | Vlan.status    | VLAN.status            |
 | siteName           | Vlan.site      | VLAN.site              |
-
-## Device Roles
-
-Although IP Fabric does not have a dedicated model that corresponds to Nautobot Device Role objects, the plugin will create new Device Roles that correspond to the synced Device's `devType` attribute. The resulting Device Role object in Nautobot will have a custom field called **IPFabric Type** that maps directly to the `devType` field in IP Fabric. You can change the Device Role's name and color without any impact between syncs. However, if you change the custom field **IPFabric Type**, then on subsequent syncs a new Device Role object will be created and the Devices that have been synced from IP Fabric will revert to using the new Device Role.

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -195,6 +195,7 @@ Site objects include a site diagram from IPFabric, which is using the new custom
 | model              | Device.model         | Device.device_type     |
 | sn                 | Device.serial_number | Device.serial          |
 
+
 ### IPFabric Interface
 
 | IP Fabric (Source) | DiffSync Model          | Nautobot (Destination)    |
@@ -218,3 +219,7 @@ Site objects include a site diagram from IPFabric, which is using the new custom
 | vlanId             | Vlan.vid       | VLAN.vid               |
 | status             | Vlan.status    | VLAN.status            |
 | siteName           | Vlan.site      | VLAN.site              |
+
+## Device Roles
+
+Although IP Fabric does not have a dedicated model that corresponds to Nautobot Device Role objects, the plugin will create new Device Roles that correspond to the synced Device's `devType` attribute. The resulting Device Role object in Nautobot will have a custom field called **IPFabric Type** that maps directly to the `devType` field in IP Fabric. You can change the Device Role's name and color without any impact between syncs. However, if you change the custom field **IPFabric Type**, then on subsequent syncs a new Device Role object will be created and the Devices that have been synced from IP Fabric will revert to using the new Device Role.

--- a/nautobot_ssot_ipfabric/diffsync/adapter_ipfabric.py
+++ b/nautobot_ssot_ipfabric/diffsync/adapter_ipfabric.py
@@ -136,7 +136,7 @@ class IPFabricDiffSync(DiffSyncModelAdapters):
                         model=device.get("model") if device.get("model") else f"Default-{device.get('vendor')}",
                         vendor=device.get("vendor").capitalize(),
                         serial_number=serial_number,
-                        role=DEFAULT_DEVICE_ROLE,
+                        role=device.get('devType') if device.get('devType') else DEFAULT_DEVICE_ROLE,
                         status=DEFAULT_DEVICE_STATUS,
                     )
                     self.add(device_model)

--- a/nautobot_ssot_ipfabric/diffsync/adapter_ipfabric.py
+++ b/nautobot_ssot_ipfabric/diffsync/adapter_ipfabric.py
@@ -136,7 +136,7 @@ class IPFabricDiffSync(DiffSyncModelAdapters):
                         model=device.get("model") if device.get("model") else f"Default-{device.get('vendor')}",
                         vendor=device.get("vendor").capitalize(),
                         serial_number=serial_number,
-                        role=device.get('devType') if device.get('devType') else DEFAULT_DEVICE_ROLE,
+                        role=device.get("devType") if device.get("devType") else DEFAULT_DEVICE_ROLE,
                         status=DEFAULT_DEVICE_STATUS,
                     )
                     self.add(device_model)

--- a/nautobot_ssot_ipfabric/diffsync/adapter_nautobot.py
+++ b/nautobot_ssot_ipfabric/diffsync/adapter_nautobot.py
@@ -122,7 +122,9 @@ class NautobotDiffSync(DiffSyncModelAdapters):
                 diffsync=self,
                 name=device_record.name,
                 model=str(device_record.device_type),
-                role=str(device_record.device_role) if str(device_record.device_role) else DEFAULT_DEVICE_ROLE,
+                role=str(device_record.device_role.cf["ipfabric_type"])
+                if str(device_record.device_role.cf["ipfabric_type"])
+                else str(device_record.device_role),
                 location_name=device_record.site.name,
                 vendor=str(device_record.device_type.manufacturer),
                 status=device_record.status.name,

--- a/nautobot_ssot_ipfabric/diffsync/adapter_nautobot.py
+++ b/nautobot_ssot_ipfabric/diffsync/adapter_nautobot.py
@@ -122,8 +122,8 @@ class NautobotDiffSync(DiffSyncModelAdapters):
                 diffsync=self,
                 name=device_record.name,
                 model=str(device_record.device_type),
-                role=str(device_record.device_role.cf["ipfabric_type"])
-                if str(device_record.device_role.cf["ipfabric_type"])
+                role=str(device_record.device_role.cf.get("ipfabric_type"))
+                if str(device_record.device_role.cf.get("ipfabric_type"))
                 else str(device_record.device_role),
                 location_name=device_record.site.name,
                 vendor=str(device_record.device_type.manufacturer),

--- a/nautobot_ssot_ipfabric/signals.py
+++ b/nautobot_ssot_ipfabric/signals.py
@@ -72,3 +72,4 @@ def nautobot_database_ready_callback(sender, *, apps, **kwargs):  # pylint: disa
     create_custom_field("ssot-synced-from-ipfabric", "Last synced from IPFabric on", synced_from_models, apps=apps)
     site_model = [Site]
     create_custom_field("ipfabric-site-id", "IPFabric Site ID", site_model, apps=apps, cf_type="type_text")
+    create_custom_field("ipfabric_type", "IPFabric Type", [DeviceRole], apps=apps, cf_type="type_text")

--- a/nautobot_ssot_ipfabric/tests/test_nbutils.py
+++ b/nautobot_ssot_ipfabric/tests/test_nbutils.py
@@ -9,7 +9,7 @@ from nautobot.ipam.models import VLAN, IPAddress
 from nautobot.utilities.choices import ColorChoices
 
 from nautobot_ssot_ipfabric.utilities import (  # create_ip,; create_interface,; create_site,
-    create_device_role_object,
+    get_or_create_device_role_object,
     create_device_type_object,
     create_manufacturer,
     create_status,
@@ -34,6 +34,8 @@ class TestNautobotUtils(TestCase):
             model="Test-DeviceType", slug="test-devicetype", manufacturer=self.manufacturer
         )
         self.device_role = DeviceRole.objects.create(name="Test-Role", slug="test-role", color=ColorChoices.COLOR_RED)
+        self.device_role.cf["ipfabric_type"] = "Test-Role"
+        self.device_role.validated_save()
         self.content_type = ContentType.objects.get(app_label="dcim", model="device")
         self.status = Status.objects.create(
             name="Test-Status",
@@ -93,9 +95,9 @@ class TestNautobotUtils(TestCase):
         test_manufacturer = create_manufacturer(vendor_name="Test-Manufacturer")
         self.assertEqual(test_manufacturer.id, self.manufacturer.id)
 
-    def test_create_device_role(self):
-        """Test `create_device_role` Utility."""
-        test_device_role = create_device_role_object("Test-Role", role_color=ColorChoices.COLOR_RED)
+    def test_get_or_create_device_role(self):
+        """Test `get_or_create_device_role` Utility."""
+        test_device_role = get_or_create_device_role_object("Test-Role", role_color=ColorChoices.COLOR_RED)
         self.assertEqual(test_device_role.id, self.device_role.id)
 
     def test_create_status(self):

--- a/nautobot_ssot_ipfabric/utilities/__init__.py
+++ b/nautobot_ssot_ipfabric/utilities/__init__.py
@@ -1,6 +1,6 @@
 """Utilities."""
 from .nbutils import (
-    create_device_role_object,
+    get_or_create_device_role_object,
     create_device_type_object,
     create_interface,
     create_ip,
@@ -15,7 +15,7 @@ __all__ = (
     "create_site",
     "create_device_type_object",
     "create_manufacturer",
-    "create_device_role_object",
+    "get_or_create_device_role_object",
     "create_status",
     "create_ip",
     "create_interface",

--- a/nautobot_ssot_ipfabric/utilities/nbutils.py
+++ b/nautobot_ssot_ipfabric/utilities/nbutils.py
@@ -5,7 +5,6 @@ from typing import Any, Optional
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError
-from django.db.models import Q
 from django.utils.text import slugify
 from nautobot.dcim.models import (
     Device,


### PR DESCRIPTION
Closes #72 

Added the creation of Nautobot Device Roles that match `devType` device attribute in IP Fabric.
Added signal to create custom field called `IPFabric Type` that maps to `devType` to ensure any changes to the Device Role on the Nautobot side persist between syncs.
Update docs and tests to reflect these changes.