### PR TITLE
Correct Documentation on SSoT Framework Requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Example `PLUGINS_CONFIG` to be updated in `nautobot_config.py` after successful 
 ability to call the sync job through chatops, you will be required to configure it.
 
 ```python
+PLUGINS = ["nautobot_ssot", "nautobot_ssot_ipfabric"]
+
 PLUGINS_CONFIG = {
     "nautobot_chatops": {
         "enable_slack": True,

--- a/docs/plugin.md
+++ b/docs/plugin.md
@@ -32,7 +32,7 @@ Once installed, the plugin needs to be enabled in your `nautobot_config.py` as w
 
 ```python
 # In your nautobot_config.py
-PLUGINS = ["nautobot_ssot_ipfabric"]
+PLUGINS = ["nautobot_ssot", "nautobot_ssot_ipfabric"]
 
 PLUGINS_CONFIG = {
   "nautobot_ssot_ipfabric": {


### PR DESCRIPTION
Updated documentation to clarify that `nautobot_ssot` is required to be in the PLUGINS list for the SSoT App to function.